### PR TITLE
Save CSV as File Annotation

### DIFF
--- a/omero_biofilefinder/urls.py
+++ b/omero_biofilefinder/urls.py
@@ -25,8 +25,8 @@ urlpatterns = [
     path("", views.index, name="omero_biofilefinder_index"),
 
     path("open_with_redirect_to_app", views.open_with_redirect_to_app,
-         name="omero_biofilefinder_openwith"),
+         name="omero_biofilefinder_openwith")#,
 
-    path("project/<int:id>/csv/", views.omero_to_csv,
-         name="omero_biofilefinder_csv"),
+#     path("project/<int:id>/csv/", views.omero_to_csv,
+#          name="omero_biofilefinder_csv"),
 ]

--- a/omero_biofilefinder/views.py
+++ b/omero_biofilefinder/views.py
@@ -142,7 +142,6 @@ def omero_to_csv(request, id, conn=None, **kwargs):
 
     # write csv to return as http response
     #with io.StringIO() as csvfile:
-    return
     tmp_path = "/tmp/bff_file.csv"
     with open(tmp_path, "w") as csvfile:
         writer = csv.writer(csvfile)

--- a/omero_biofilefinder/views.py
+++ b/omero_biofilefinder/views.py
@@ -165,7 +165,7 @@ def omero_to_csv(request, id, conn=None, **kwargs):
                 "%Y-%m-%d %H:%M:%S.%Z"))
             writer.writerow(row)
 
-        group_id = project.getDetails().group.id
+        group_id = project.getDetails().getGroup().getId()
         conn.SERVICE_OPTS.setOmeroGroup(group_id)
         file_ann = conn.createFileAnnfromLocalFile(
             tmp_path, mimetype="text/plain", ns="BFF", desc=None)

--- a/omero_biofilefinder/views.py
+++ b/omero_biofilefinder/views.py
@@ -165,13 +165,12 @@ def omero_to_csv(request, id, conn=None, **kwargs):
                 "%Y-%m-%d %H:%M:%S.%Z"))
             writer.writerow(row)
 
-        group_id = project.getDetails().getGroup().getId()
-        conn.SERVICE_OPTS.setOmeroGroup(group_id)
-        print(conn.SERVICE_OPTS.getOmeroGroup())
-        file_ann = conn.createFileAnnfromLocalFile(
-            tmp_path, mimetype="text/plain", ns="BFF", desc=None)
-        anno = project.linkAnnotation(file_ann)
-        return anno.id
+    group_id = project.getDetails().getGroup().getId()
+    conn.SERVICE_OPTS.setOmeroGroup(group_id)
+    file_ann = conn.createFileAnnfromLocalFile(
+        tmp_path, mimetype="text/plain", ns="BFF", desc=None)
+    anno = project.linkAnnotation(file_ann)
+    return anno.id
         
 
         #response = HttpResponse(csvfile.getvalue(), content_type="text/csv")

--- a/omero_biofilefinder/views.py
+++ b/omero_biofilefinder/views.py
@@ -58,9 +58,9 @@ def open_with_redirect_to_app(request, conn=None, **kwargs):
 
     project_id = request.GET.get("project")
     anno_id = omero_to_csv(request, project_id, conn=conn, **kwargs)
-    csv_url = request.build_absolute_uri(reverse("webclient"))
+    csv_url = request.build_absolute_uri(reverse("webindex"))
             # we end url with .png so that BFF enables open-with "Browser"
-    csv_url += f"/annotation/{anno_id}&_=.csv"
+    csv_url += f"annotation/{anno_id}&_=.csv"
     csv_url = wrap_url(request, csv_url, conn)
 
     # Including the sessionUuid allows request from BFF to join the session

--- a/omero_biofilefinder/views.py
+++ b/omero_biofilefinder/views.py
@@ -137,7 +137,8 @@ def omero_to_csv(request, id, conn=None, **kwargs):
     column_names.append("Uploaded")
 
     # write csv to return as http response
-    with io.StringIO() as csvfile:
+    #with io.StringIO() as csvfile:
+    with open(tmp_path, "w") as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(column_names)
         for image_id in image_ids:
@@ -159,5 +160,8 @@ def omero_to_csv(request, id, conn=None, **kwargs):
                 "%Y-%m-%d %H:%M:%S.%Z"))
             writer.writerow(row)
 
+        file_ann = conn.createFileAnnfromLocalFile(
+            tmp_path, mimetype="text/plain", ns="BFF", desc=None)
+        
         response = HttpResponse(csvfile.getvalue(), content_type="text/csv")
         return response

--- a/omero_biofilefinder/views.py
+++ b/omero_biofilefinder/views.py
@@ -104,7 +104,7 @@ def open_with_redirect_to_app(request, conn=None, **kwargs):
     return HttpResponseRedirect(url)
 
 
-@login_required()
+#@login_required()
 def omero_to_csv(request, id, conn=None, **kwargs):
 
     project = conn.getObject("Project", id)
@@ -142,6 +142,7 @@ def omero_to_csv(request, id, conn=None, **kwargs):
 
     # write csv to return as http response
     #with io.StringIO() as csvfile:
+    return
     tmp_path = "/tmp/bff_file.csv"
     with open(tmp_path, "w") as csvfile:
         writer = csv.writer(csvfile)
@@ -167,6 +168,7 @@ def omero_to_csv(request, id, conn=None, **kwargs):
 
         group_id = project.getDetails().getGroup().getId()
         conn.SERVICE_OPTS.setOmeroGroup(group_id)
+        print(conn.SERVICE_OPTS.getOmeroGroup())
         file_ann = conn.createFileAnnfromLocalFile(
             tmp_path, mimetype="text/plain", ns="BFF", desc=None)
         anno = project.linkAnnotation(file_ann)

--- a/omero_biofilefinder/views.py
+++ b/omero_biofilefinder/views.py
@@ -58,7 +58,9 @@ def open_with_redirect_to_app(request, conn=None, **kwargs):
 
     project_id = request.GET.get("project")
     anno_id = omero_to_csv(request, project_id, conn=conn, **kwargs)
-    csv_url = f"http://ctome01ld.jax.org:4080/webclient/annotation/{anno_id}"
+    csv_url = request.build_absolute_uri(reverse("webclient"))
+            # we end url with .png so that BFF enables open-with "Browser"
+    csv_url += f"/annotation/{anno_id}&_=.csv"
     csv_url = wrap_url(request, csv_url, conn)
 
     # Including the sessionUuid allows request from BFF to join the session
@@ -163,6 +165,8 @@ def omero_to_csv(request, id, conn=None, **kwargs):
                 "%Y-%m-%d %H:%M:%S.%Z"))
             writer.writerow(row)
 
+        group_id = project.getDetails().group.id
+        conn.SERVICE_OPTS.setOmeroGroup(group_id)
         file_ann = conn.createFileAnnfromLocalFile(
             tmp_path, mimetype="text/plain", ns="BFF", desc=None)
         anno = project.linkAnnotation(file_ann)

--- a/omero_biofilefinder/views.py
+++ b/omero_biofilefinder/views.py
@@ -59,7 +59,7 @@ def open_with_redirect_to_app(request, conn=None, **kwargs):
     project_id = request.GET.get("project")
     anno_id = omero_to_csv(request, project_id, conn=conn, **kwargs)
     csv_url = request.build_absolute_uri(reverse("webindex"))
-            # we end url with .png so that BFF enables open-with "Browser"
+    # idk if need to end url with .csv for BFF, but doing it just in case
     csv_url += f"annotation/{anno_id}&_=.csv"
     csv_url = wrap_url(request, csv_url, conn)
 


### PR DESCRIPTION
Work from the OME 2025 Community Meeting hackathon at the Broad: when `open with` is triggered, it generates a CSV and saves that as a File Annotation to the Project, then provides the link to that CSV to BFF. 

This still is likely to time out with larger projects - it is better to pre-generate the CSV in an OMERO script as in https://github.com/will-moore/omero-biofilefinder/pull/4.

The changes to lines [views.py#L61-64](https://github.com/govekk/omero-biofilefinder/blob/9fa169a737ec04676e3b4b05697ca46cb0389852/omero_biofilefinder/views.py#L61-L64) are maybe still useful in the context of that PR since they provide the link to the CSV using the "webindex" URL. 

@will-moore feel free to merge or discard any of this, or change the destination branch of the PR if useful :)  I'll try to test out your scripts PR when I get the chance