### PR TITLE
add table_to_parquet() support

### DIFF
--- a/omero_biofilefinder/templates/omero_biofilefinder/open_with_bff.html
+++ b/omero_biofilefinder/templates/omero_biofilefinder/open_with_bff.html
@@ -64,6 +64,22 @@
             </p>
         {% endif %}
 
+        {% if table_anns %}
+            <h3>OMERO.tables:</h3>
+            <ul>
+            {% for ann in table_anns %}
+                <li>
+                    {{ ann.name }} (Created: {{ ann.created }} Size: {{ ann.size }} bytes)
+                    <a class="button_link" href="{{ ann.bff_url }}">Open table in Biofile Finder</a>
+                </li>
+            {% endfor %}
+            </ul>
+        {% else %}
+            <p>
+                No OMERO.table files currently attached to {{ target.dtype | capfirst }}:{{ target.id }}.
+            </p>
+        {% endif %}
+
         <p>
             To export Key-Value pairs to a parquet file, you can run an OMERO script:
             Select the Project in the webclient, then use the OMERO.script menu and choose:

--- a/omero_biofilefinder/urls.py
+++ b/omero_biofilefinder/urls.py
@@ -22,18 +22,21 @@ from . import views
 from omeroweb.webclient.views import download_annotation
 
 urlpatterns = [
-    # index 'home page' of the app
-    path("", views.index, name="omero_biofilefinder_index"),
+     # index 'home page' of the app
+     path("", views.index, name="omero_biofilefinder_index"),
 
-    path("open_with_bff", views.open_with_bff,
+     path("open_with_bff", views.open_with_bff,
          name="omero_biofilefinder_openwith"),
 
-    # when BFF loads a parquet file, the url needs to end with .parquet
-    path("fileann/<int:annId>/omero.parquet", download_annotation,
+     # when BFF loads a parquet file, the url needs to end with .parquet
+     path("fileann/<int:annId>/omero.parquet", download_annotation,
          name="omero_biofilefinder_fileann"),
+     
+     path("table/<int:annId>/omero.parquet", views.table_to_parquet,
+         name="omero_biofilefinder_table_to_parquet"),
 
-    path("project/<int:id>/csv/", views.omero_to_csv,
+     path("project/<int:id>/csv/", views.omero_to_csv,
          name="omero_biofilefinder_csv"),
 
-    re_path(r'^bff/app/(?P<url>.*)$', views.app, name='bff_static'),
+     re_path(r'^bff/app/(?P<url>.*)$', views.app, name='bff_static'),
 ]


### PR DESCRIPTION
Much faster than loading Key-Value pairs from each Image is to convert OMERO.table to BFF parquet file on the fly.

